### PR TITLE
Do not add hidden 'id' field if binding a non existent mapper. Fixes T170

### DIFF
--- a/src/Cubex/Form/Form.php
+++ b/src/Cubex/Form/Form.php
@@ -166,7 +166,10 @@ class Form extends DataMapper implements IRenderable
 
         if($mapper->getIdKey() == $a->name())
         {
-          $this->addHiddenElement($a->name(), $a->data());
+          if($mapper->exists())
+          {
+            $this->addHiddenElement($a->name(), $a->data());
+          }
         }
         else
         {


### PR DESCRIPTION
Proposed fix for http://phabricator.cubex.io/T170
