### PR TITLE
Delete text container entries when parent translation mapper is deleted. Fixes T169

### DIFF
--- a/src/Cubex/Mapper/Database/I18n/I18nRecordMapper.php
+++ b/src/Cubex/Mapper/Database/I18n/I18nRecordMapper.php
@@ -161,4 +161,17 @@ abstract class I18nRecordMapper extends RecordMapper
     $this->_loadProperties();
     return parent::getData($attribute);
   }
+
+  public function delete()
+  {
+    parent::delete();
+    $textContainers = new RecordCollection($this->getTextContainer());
+    $textContainers = $textContainers->loadAll();
+    foreach($textContainers as $textContainer)
+    {
+      $textContainer->delete();
+    }
+
+    return $this;
+  }
 }


### PR DESCRIPTION
Proposed fix for http://phabricator.cubex.io/T169
