### PR TITLE
fixed namespace by trimming off backslash at the beginning 

### DIFF
--- a/src/Cubex/Dispatch/Utils/RequireTrait.php
+++ b/src/Cubex/Dispatch/Utils/RequireTrait.php
@@ -243,11 +243,13 @@ trait RequireTrait
   {
     if($this instanceof INamespaceAware)
     {
-      return $this->getNamespace();
+      $ns = $this->getNamespace();
     }
     else
     {
-      return Dispatcher::getNamespaceFromSource($this);
+      $ns =  Dispatcher::getNamespaceFromSource($this);
     }
+
+    return ltrim($ns,'\\');
   }
 }


### PR DESCRIPTION
Hey Brooke,

As we found last week, dispatcher was broken because of the difference is the namespace string. Please can you pull in this fix for it

Cheers